### PR TITLE
Add CLAUDE.md setup guidance to documentation

### DIFF
--- a/.claude/QUICKSTART.md
+++ b/.claude/QUICKSTART.md
@@ -7,7 +7,7 @@ Safety system for using Claude Code with terraform that:
 - Prompts for approval on safe commands (`plan`, `validate`, `fmt`, etc.)
 - Logs all terraform operations with timestamps
 
-## Installation (5 minutes)
+## Installation
 
 ### 1. Prerequisites
 
@@ -19,14 +19,48 @@ python3 --version
 claude --version
 ```
 
-### 2. Verify Files Are in Place
+### 2. Create Your CLAUDE.md File
+
+Create a `CLAUDE.md` file at the root of your repo to give Claude context about your infrastructure:
+
+```bash
+cat > CLAUDE.md << 'EOF'
+# Infrastructure Context
+
+## What This Repo Manages
+
+- [Brief description of infrastructure]
+- GCP projects: [list your projects]
+- Environments: dev, staging, prod
+
+## Important Constraints
+
+- Never run terraform apply - all changes go through PR workflow
+- [Add your team-specific rules here]
+
+## File Structure
+
+- `modules/` - Reusable terraform modules
+- `environments/` - Per-environment configurations
+- [Describe your actual structure]
+
+## Getting Help
+
+- Team channel: #your-team-channel
+- On-call: [your oncall process]
+EOF
+```
+
+Customize this for your actual infrastructure. Claude reads this file to understand your repo. See [DEPLOYMENT.md](./docs/DEPLOYMENT.md#repository-structures-and-context-files) for nested CLAUDE.md patterns in monorepos.
+
+### 3. Verify Hook Files Are in Place
 
 ```bash
 ls -la .claude/
 # Should see: hooks/, docs/, settings.json
 ```
 
-### 3. Test the Hooks
+### 4. Test the Hooks
 
 ```bash
 # Run automated tests
@@ -42,7 +76,7 @@ PASS: Non-terraform commands allowed
 PASS: Audit log created
 ```
 
-### 4. Try It Out
+### 5. Try It Out
 
 ```bash
 # Start Claude Code in this repo

--- a/.claude/docs/README.md
+++ b/.claude/docs/README.md
@@ -127,6 +127,105 @@ Example log entry:
 
 ---
 
+## Setting Up Your CLAUDE.md
+
+Claude Code reads `CLAUDE.md` files to understand your repository. Creating one for your infrastructure repo gives Claude essential context about your environment, constraints, and conventions.
+
+### Why This Matters
+
+Without context, Claude treats your repo as generic terraform. With a good `CLAUDE.md`, Claude understands:
+- Which GCP projects you manage
+- What environments exist (dev/staging/prod)
+- Team-specific naming conventions
+- What actions require extra caution
+
+### Create Your CLAUDE.md
+
+Add a `CLAUDE.md` file at the root of your repo:
+
+```markdown
+# Infrastructure Context
+
+## What This Repo Manages
+
+Brief description of what infrastructure this repo controls.
+
+- GCP projects: project-dev, project-staging, project-prod
+- Kubernetes clusters: [list clusters]
+- Key services: [what runs here]
+
+## Environments
+
+- **dev** - Development environment, safe to experiment
+- **staging** - Pre-production, mirrors prod configuration
+- **prod** - Production, all changes require extra review
+
+## Important Constraints
+
+- All terraform applies go through PR workflow (never run apply directly)
+- Production changes require approval from @platform-team
+- [Add your team-specific rules]
+
+## File Structure
+
+Describe your repo layout so Claude can navigate effectively:
+
+- `modules/` - Reusable terraform modules
+- `environments/dev/` - Dev environment configuration
+- `environments/prod/` - Production configuration
+- `scripts/` - Automation scripts
+
+## Naming Conventions
+
+- Resources: `{project}-{env}-{resource-type}-{name}`
+- Modules: lowercase with hyphens
+- [Your conventions here]
+
+## Getting Help
+
+- Team channel: #your-sre-channel
+- Documentation: [link to wiki]
+```
+
+### Nested CLAUDE.md Files for Monorepos
+
+For large monorepos, you can add `CLAUDE.md` files in subdirectories. Claude reads all relevant files as it navigates your codebase:
+
+```
+infrastructure/
+├── CLAUDE.md                    # Root: Organization-wide context
+├── bootstrap/
+│   ├── CLAUDE.md               # Specific: Tenant provisioning details
+│   └── terraform/
+├── networking/
+│   ├── CLAUDE.md               # Specific: VPC and firewall context
+│   └── terraform/
+└── compute/
+    ├── CLAUDE.md               # Specific: GKE cluster details
+    └── terraform/
+```
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md#repository-structures-and-context-files) for detailed patterns and examples.
+
+### Personal Preferences with CLAUDE.local.md
+
+For your personal working style (not committed to git):
+
+```bash
+# Create personal preferences file (gitignored)
+cat > CLAUDE.local.md << 'EOF'
+# My Preferences
+
+- Always run terraform fmt before showing me code
+- I prefer explicit variable names over abbreviations
+- My default GCP project: dev-myname-sandbox
+EOF
+```
+
+Add `CLAUDE.local.md` and `**/CLAUDE.local.md` to your `.gitignore`.
+
+---
+
 ## Common Workflows
 
 ### Workflow 1: Making Terraform Changes


### PR DESCRIPTION
- Add step 2 in QUICKSTART.md with template for creating CLAUDE.md
- Add "Setting Up Your CLAUDE.md" section in README.md covering:
  - Why context matters for Claude Code
  - Complete CLAUDE.md template with key sections
  - Nested CLAUDE.md patterns for monorepos
  - CLAUDE.local.md for personal preferences
- Link to existing detailed patterns in DEPLOYMENT.md