### PR TITLE
Add tofu alias support and remove devcontainer warning from hooks

### DIFF
--- a/.claude/hooks/helm-validator.py
+++ b/.claude/hooks/helm-validator.py
@@ -10,7 +10,6 @@ Scoped to Helm chart development workflows. Encourages local validation
 Behavior:
 - BLOCKS: helm install, upgrade, uninstall, rollback, test (cluster mutations)
 - PROMPTS: helm template, lint, show, dependency, package, etc. (local dev)
-- WARNS: If not running in devcontainer (encourages consistent environment)
 - LOGS: All helm command attempts to .claude/audit/helm-YYYY-MM-DD.log
 
 Usage:
@@ -30,7 +29,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from hook_utils import (
     get_dated_audit_log_path,
-    get_container_warning,
     get_tool_stages,
     log_command,
 )
@@ -112,8 +110,6 @@ def check_command(command, cwd):
         if re.search(rf"\b{kw}\b", command, re.IGNORECASE)
     ]
 
-    container_warning = get_container_warning("helm")
-
     if suspicious:
         keywords = ", ".join(suspicious)
         reason = (
@@ -123,7 +119,6 @@ def check_command(command, cwd):
             f"  Working directory: {cwd}\n\n"
             f"This may be using variables, eval, or other indirection to run a\n"
             f"blocked operation. Review the full command carefully before approving."
-            f"{container_warning}"
         )
         log_command(
             AUDIT_LOG,
@@ -138,7 +133,6 @@ def check_command(command, cwd):
             f"  Command: {command}\n"
             f"  Working directory: {cwd}\n\n"
             f"This prompt ensures you review each helm operation before execution."
-            f"{container_warning}"
         )
         log_command(
             AUDIT_LOG, command, "PENDING_APPROVAL", cwd, "Awaiting user approval"

--- a/.claude/hooks/terraform-validator.py
+++ b/.claude/hooks/terraform-validator.py
@@ -7,7 +7,6 @@ Pre-execution hook that validates terraform commands before Claude runs them.
 Behavior:
 - BLOCKS: terraform apply, destroy, import, and state manipulation commands
 - PROMPTS: All other terraform commands (plan, init, fmt, validate, etc.)
-- WARNS: If not running in devcontainer (encourages consistent environment)
 - LOGS: All terraform command attempts to .claude/audit/terraform-YYYY-MM-DD.log
 
 Usage:
@@ -27,7 +26,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 from hook_utils import (
     get_dated_audit_log_path,
-    get_container_warning,
     get_tool_stages,
     log_command,
 )
@@ -42,9 +40,9 @@ AUDIT_LOG = get_dated_audit_log_path("terraform")
 # - Wrapper SCRIPTS in $PATH (e.g., ~/bin/tf)
 # - Common shorthand commands your team uses
 #
-# Default list covers: terraform, tf, tform
+# Default list covers: terraform, tf, tform, tofu (OpenTofu)
 # Add your custom wrapper scripts here if needed (e.g., tfm, tfwrapper, etc.)
-TF_COMMAND = r"\b(terraform|tf|tform)\b"
+TF_COMMAND = r"\b(terraform|tf|tform|tofu)\b"
 
 # Terraform global flags use = syntax for values (e.g., -chdir=DIR),
 # so any -prefixed token is self-contained (no space-separated values to skip).
@@ -114,8 +112,6 @@ def check_command(command, cwd):
         if re.search(rf"\b{kw}\b", command, re.IGNORECASE)
     ]
 
-    container_warning = get_container_warning("terraform")
-
     if suspicious:
         keywords = ", ".join(suspicious)
         reason = (
@@ -125,7 +121,6 @@ def check_command(command, cwd):
             f"  Working directory: {cwd}\n\n"
             f"This may be using variables, eval, or other indirection to run a\n"
             f"blocked operation. Review the full command carefully before approving."
-            f"{container_warning}"
         )
         log_command(
             AUDIT_LOG,
@@ -140,7 +135,6 @@ def check_command(command, cwd):
             f"  Command: {command}\n"
             f"  Working directory: {cwd}\n\n"
             f"This prompt ensures you review each terraform operation before execution."
-            f"{container_warning}"
         )
         log_command(
             AUDIT_LOG, command, "PENDING_APPROVAL", cwd, "Awaiting user approval"

--- a/.claude/hooks/test_terraform_validator.py
+++ b/.claude/hooks/test_terraform_validator.py
@@ -76,6 +76,10 @@ class TestBlockedCommands:
             pytest.param("tf destroy", id="tf-destroy"),
             pytest.param("tform apply", id="tform-apply"),
             pytest.param("tform destroy", id="tform-destroy"),
+            pytest.param("tofu apply", id="tofu-apply"),
+            pytest.param("tofu destroy", id="tofu-destroy"),
+            pytest.param("tofu import aws_instance.foo i-1234", id="tofu-import"),
+            pytest.param("tofu state rm aws_instance.foo", id="tofu-state-rm"),
         ],
     )
     def test_aliases_blocked(self, cmd):
@@ -145,6 +149,8 @@ class TestPromptedCommands:
             pytest.param("terraform providers", id="providers"),
             pytest.param("tf plan", id="tf-plan"),
             pytest.param("tform init", id="tform-init"),
+            pytest.param("tofu plan", id="tofu-plan"),
+            pytest.param("tofu init -no-color", id="tofu-init"),
         ],
     )
     def test_safe_commands_prompt(self, cmd):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ AGENTS.local.md                # Personal preferences (gitignored, optional)
 ### Alias Handling
 
 - Hardcoded list of common command names per tool:
-  - Terraform: `terraform`, `tf`, `tform`
+  - Terraform: `terraform`, `tf`, `tform`, `tofu`
   - Helm: `helm`
 - Shell aliases don't work in subprocess calls, so they can't bypass hooks anyway
 - The list catches wrapper **scripts** in PATH, not shell aliases


### PR DESCRIPTION
## Summary
- Add `tofu` (OpenTofu) to the terraform validator command pattern alongside `terraform`, `tf`, and `tform`
- Remove devcontainer warning from terraform and helm validators (can be re-added later)
- Add test cases for `tofu` commands (blocked: apply/destroy/import/state-rm, prompted: plan/init)
- Update AGENTS.md alias list to document `tofu`

## Test plan
- [ ] Run `pytest .claude/hooks/` — all 100 tests pass
- [ ] Verify `tofu apply` is blocked by the terraform validator
- [ ] Verify `tofu plan` prompts for approval

🤖 Generated with [Claude Code](https://claude.ai/code)